### PR TITLE
feat(reset): add check for password check with old one during reset

### DIFF
--- a/actions/new-password.ts
+++ b/actions/new-password.ts
@@ -37,7 +37,7 @@ export const newPassword = async (
   if (!existingUser) {
     return { error: "Email does not exist" };
   }
-  console.log(`Eixsting User's id : ${existingUser.id}`);
+  console.log(`Existing User's id : ${existingUser.id}`);
   // hashing the new password and updating it in the database
   const hashedPassword = await bcryptjs.hash(password, 10);
   console.log(`password:${password}`);

--- a/actions/password-reset-security.ts
+++ b/actions/password-reset-security.ts
@@ -55,6 +55,12 @@ export const passwordResetSecurity = async (
     return { error: "Both the fields are required!" };
   }
 
+  // check if the newly entered password is the same as the previous password
+  const isSamePassword = await bcryptjs.compare(values.password, dbUser.password!);
+  if (isSamePassword) {
+    return { error: "New password must not match the old password" };
+  }
+
   // if everything is fine then we will proceed to update the password
   // hashing the new password using bcrypt
   const hashedNewPassword = await bcryptjs.hash(values.password, 10);

--- a/components/auth/new-password-form.tsx
+++ b/components/auth/new-password-form.tsx
@@ -38,6 +38,7 @@ export const NewPasswordForm = () => {
     resolver: zodResolver(NewPasswordSchema),
     defaultValues: {
       password: "",
+      confirmPassword: "",
     },
   });
 
@@ -73,6 +74,24 @@ export const NewPasswordForm = () => {
             render={({ field }) => (
               <FormItem>
                 <FormLabel>Password</FormLabel>
+                <FormControl>
+                  <Input
+                    {...field}
+                    placeholder="******"
+                    type="password"
+                    disabled={isPending}
+                  />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          <FormField
+            control={form.control}
+            name="confirmPassword"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Confirm Password</FormLabel>
                 <FormControl>
                   <Input
                     {...field}

--- a/schema/index.tsx
+++ b/schema/index.tsx
@@ -1,11 +1,24 @@
 import * as z from "zod";
 
-export const NewPasswordSchema = z.object({
-  /* the .min() function is used to specify that a minimum of 1 character is required */
-  password: z.string().min(6, {
-    message: "Minimum 6 characters required",
-  }),
-});
+export const NewPasswordSchema = z
+  .object({
+    /* the .min() function is used to specify that a minimum of 1 character is required */
+    password: z.string().min(6, {
+      message: "Minimum 6 characters required",
+    }),
+    confirmPassword: z.string().min(6, {
+      message: "Minimum 6 characters required",
+    }),
+  })
+  .refine(
+    (data) => {
+      return data.password === data.confirmPassword;
+    },
+    {
+      message: "Passwords do not match",
+      path: ["confirmPassword"],
+    }
+  );
 
 export const PasswordResetSchema = z.object({
   email: z


### PR DESCRIPTION
## ⚙️ Change Summary

- Added support for validating if the new password entered on the reset password matches the old password. If it does match, then an error message is displayed for the user.
- Added two password fields (New Password and Confirm Password) instead of just a single Password field

Resolves: https://github.com/passenger016/next_auth/issues/11 